### PR TITLE
Improve docker build in github action

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v6
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -25,3 +25,5 @@ jobs:
         with:
           push: true
           tags: bonyuta0204/github-remainder:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'main'
-      - feat/build-ci
+      - feat/docker-cache
 
 jobs:
   docker:
@@ -12,16 +12,16 @@ jobs:
     steps:
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v6
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: bonyuta0204/github-remainder:latest


### PR DESCRIPTION
# Docker Build Optimization for GitHub Actions

This document details the current state of our Docker build process, performance bottlenecks, and steps we plan to take to optimize the workflow. Our goal is to minimize build times while ensuring smooth integration with GitHub Actions.

## Current GitHub Action Setup

Below is the current configuration of our GitHub Actions workflow for building and pushing Docker images.

### GitHub Action Workflow

```yaml
name: Build and Push Image

on:
  push:
    branches:
      - 'main'
      - feat/docker-cache

jobs:
  docker:
    runs-on: ubuntu-latest
    steps:
      - name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v3
        with:
          install: true
          driver-opts: image=moby/buildkit:master,network=host

      - name: Login to Docker Hub
        uses: docker/login-action@v3
        with:
          username: ${{ secrets.DOCKERHUB_USERNAME }}
          password: ${{ secrets.DOCKERHUB_TOKEN }}

      - name: Build and push with cache
        uses: docker/build-push-action@v6
        with:
          push: true
          tags: bonyuta0204/github-remainder:latest
          cache-from: type=gha
          cache-to: type=gha,mode=max
```

### Dockerfile

The Dockerfile currently uses a two-stage build process to optimize the resulting image.

```dockerfile
FROM fpco/stack-build:lts-20.5 as build
RUN mkdir /opt/build
COPY . /opt/build
RUN cd /opt/build && stack build --system-ghc && stack install

FROM ubuntu:18.04
RUN mkdir -p /opt/myapp
ARG BINARY_PATH
WORKDIR /opt/myapp

ENV LANG C.UTF-8
ENV LANGUAGE C.UTF-8
ENV LC_ALL C.UTF-8

RUN apt-get update && apt-get install -y \
  ca-certificates \
  libgmp-dev

COPY --from=build /root/.local/bin .
CMD ["./github-remainder"]
```

### Performance Improvement

- The current Docker build and push process initially took more than **7 minutes 52 seconds** on the first try.
  - [GitHub Actions Run](https://github.com/bonyuta0204/github-remainder/actions/runs/11972785821/job/33380383472)
- The second run took **8 minutes 11 seconds**, indicating that the current setup was not utilizing caching at all.
- **After Setting Up Cache**: With the cache properly configured, the build time reduced dramatically to **20 seconds**.

## Optimization Strategy

### 1. Enable Docker Layer Caching

Currently, it is not clear if Docker caching is being utilized effectively. To leverage caching for repeated builds, we plan to:
- Use Docker cache to reduce build times, especially for unchanged layers.
- Modify the GitHub Actions workflow to explicitly enable caching:
  ```yaml
  - name: Build and push with cache
    uses: docker/build-push-action@v6
    with:
      push: true
      tags: bonyuta0204/github-remainder:latest
      cache-from: type=gha
      cache-to: type=gha,mode=max
  ```

### 2. Optimize Dockerfile for Cache Efficiency

Dockerfile optimization can also help reduce build times:
- **Reorder Dockerfile instructions** to maximize layer caching. For instance, moving commands that rarely change (e.g., installing packages) earlier in the Dockerfile.
- **Use multi-stage builds** more effectively to keep the final image lightweight.
- **Minimize ARG Usage**: Ensure that ARGs that change frequently are only used where necessary to avoid invalidating cached layers.

### 3. Utilize Buildx with Cache Imports

Using `docker/setup-buildx-action` to enable cache imports for cross-run caching:
- Configure `setup-buildx-action` to use remote cache storage, so cached layers from previous runs can be reused.

### Next Steps

- **Continue monitoring build times** to ensure caching is consistently effective.
- **Update the GitHub Actions workflow** to use additional cache strategies if needed.
- **Analyze Logs** to determine if specific layers are still being rebuilt unnecessarily and identify further optimizations.

## Results

After implementing Docker caching:

- ![Screenshot 1](https://github.com/user-attachments/assets/1688c584-f750-423e-bf49-950d6f20fce6)
- ![Screenshot 2](https://github.com/user-attachments/assets/be4cfe14-d742-497e-b6d6-68883e46dacc)

- The build time was reduced from over **7 minutes 52 seconds** to just **20 seconds**, representing a significant improvement in efficiency.
- The successful use of caching has dramatically decreased the time required for subsequent builds, making the development process more efficient and allowing for quicker iterations.

## References

- [GitHub Actions for Docker Build](https://github.com/docker/build-push-action)
- [Optimizing Dockerfile Builds](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
- [Docker Caching with GitHub Actions](https://docs.docker.com/build/ci/github-actions/cache/)



